### PR TITLE
fix(#11): Correct py-directus version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
 openai-agents>=0.0.19
-py-directus>=0.6.0
+py-directus>=0.0.30
 openai>=1.87.0
 pydantic>=2.10.0
 python-multipart>=0.0.12


### PR DESCRIPTION
## Summary
- Fixed Docker build failure by correcting py-directus version constraint
- Changed from `>=0.6.0` to `>=0.0.30` as version 0.6.0 doesn't exist on PyPI

## Test plan
- [x] Docker build now completes successfully
- [x] All dependencies install without errors

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)